### PR TITLE
Use post for payment

### DIFF
--- a/app/controllers/spree/payu_controller.rb
+++ b/app/controllers/spree/payu_controller.rb
@@ -2,6 +2,8 @@ module Spree
   class PayuController < Spree::StoreController
     protect_from_forgery except: :notify
 
+    before_filter :load_payment_method, only: :pay
+
     # explicit list is requred because all OpenPayU errors
     # are defined in global module and inherit from StandardError
     [
@@ -52,11 +54,13 @@ module Spree
 
     private
 
-    def payment_success
-      payment_method = Spree::PaymentMethod.find(params[:payment_method_id])
+    def load_payment_method
+      @payment_method = Spree::PaymentMethod::Payu.find(params[:payment_method_id])
+    end
 
+    def payment_success
       payment = current_order.payments.build(
-        payment_method_id: payment_method.id,
+        payment_method_id: @payment_method.id,
         amount: current_order.total,
         state: 'checkout'
       )

--- a/app/views/spree/checkout/payment/_payu.html.erb
+++ b/app/views/spree/checkout/payment/_payu.html.erb
@@ -1,1 +1,1 @@
-<%= link_to Spree.t(:pay_with_payu), pay_with_payu_path(payment_method_id: payment_method.id) %>
+<%= link_to Spree.t(:pay_with_payu), pay_with_payu_path(payment_method_id: payment_method.id), method: :post %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Spree::Core::Engine.routes.draw do
   post '/payu/notify', to: 'payu#notify'
-  get '/payu/pay', to: 'payu#pay', as: :pay_with_payu
+  post '/payu/pay', to: 'payu#pay', as: :pay_with_payu
 end


### PR DESCRIPTION
This makes `/payu/pay` route works only for `POST` requests.

As a bonus, adds a guard for this route that will `404` if requested with non-payu `:payment_method_id`
