### PR TITLE
Add/remove classes instead of hiding stuff with JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Configuration
 
 Don't forget to insert seller account details into `config/initializers/openpayu.rb`
 
+Pay with Payu button
+--------------------
+
+`spree_payu_integration` adds a `payu_selected` css class to `form#checkout_form_payment`
+when PayU payment is selected, and removes this class if some other payment
+is choosen. To use this functionality, just add `//= require spree/frontend/spree_payu_integration` to your `application.js`.
+
+This is so developer can conditionally hide "Save and Continue" button with css,
+so "Pay with PayU" button can be positioned in exact same spot than "Save and Continue".
+
+**REMEMBER: This is your job to write CSSes that hides "Save and Continue" button.**
+
 Testing
 -------
 

--- a/app/assets/javascripts/spree/frontend/spree_payu_integration.js
+++ b/app/assets/javascripts/spree/frontend/spree_payu_integration.js
@@ -1,14 +1,7 @@
-/* Placeholder for backend dummy app */
 (function($) {
-  SpreePayuIntegration = {
-    updateSaveAndContinueVisibility: function(e) {
-      if (this.isPayuChoosen(e)) {
-        console.log('yes');
-        this.hideSaveAndContinue();
-      } else {
-        console.log('no');
-        this.showSaveAndContinue();
-      }
+  var SpreePayuIntegration = {
+    updatePayuSelectedClass: function(e) {
+      $('#checkout_form_payment').toggleClass('payu_selected', this.isPayuChoosen(e));
     },
 
     isPayuChoosen: function(e) {
@@ -25,21 +18,13 @@
 
     payuPaymentMethodId: function() {
       return $('#payu_button').data('payment-method-id');
-    },
-
-    hideSaveAndContinue: function() {
-      $('[data-hook="buttons"] button').hide();
-    },
-
-    showSaveAndContinue: function() {
-      $('[data-hook="buttons"] button').show();
     }
   }
 
   $(document).ready(function() {
-    SpreePayuIntegration.updateSaveAndContinueVisibility();
+    SpreePayuIntegration.updatePayuSelectedClass();
 
-    var onPaymentMethodChange = SpreePayuIntegration.updateSaveAndContinueVisibility.bind(SpreePayuIntegration);
-    $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(onPaymentMethodChange);
+    var onPaymentMethodRadioClick = SpreePayuIntegration.updatePayuSelectedClass.bind(SpreePayuIntegration);
+    $('div[data-hook="checkout_payment_step"] input[type="radio"]').change(onPaymentMethodRadioClick);
   })
 })(jQuery);


### PR DESCRIPTION
This is better implementation of "SaveAndContinue" button hiding.
It leverages css and just toggles `payu_selected` class on
`form#checkout_payment_step`, so developer can write custom
css that hides 'SaveAndContinue' and positions 'PayWithPayu' button
in that place.
