### PR TITLE
Add missing order.next call

### DIFF
--- a/app/controllers/spree/payu_controller.rb
+++ b/app/controllers/spree/payu_controller.rb
@@ -70,6 +70,11 @@ module Spree
         redirect_to checkout_state_path(current_order.state) and return
       end
 
+      unless current_order.next
+        flash[:error] = Spree.t('cannot_advance_order_state')
+        redirect_to checkout_state_path(current_order.state) and return
+      end
+
       payment.pend!
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,4 @@ en:
   order_description: "Order from %{name}"
   spree:
     pay_with_payu: Pay with PayU
+    cannot_advance_order_state: 'Cannot advance order state'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2,3 +2,4 @@ pl:
   order_description: "Zamówienie z %{name}"
   spree:
     pay_with_payu: Zapłać z PayU
+    cannot_advance_order_state: 'Nie można przejść do następnego stanu zamówienia'

--- a/spec/controllers/spree/payu_controller_spec.rb
+++ b/spec/controllers/spree/payu_controller_spec.rb
@@ -238,6 +238,19 @@ RSpec.describe Spree::PayuController, type: :controller do
             expect(subject).to redirect_to("http://payu.com/redirect/url/4321")
           end
 
+          it 'advances order to next state' do
+            expect(order).to receive(:next).and_return(true)
+
+            subject
+          end
+
+          it 'redirects to payment page if advancing of order failed' do
+            allow(order).to receive(:next).and_return(false)
+
+            expect(subject).to redirect_to checkout_state_path(state: 'payment')
+            expect(flash[:error]).to include Spree.t('cannot_advance_order_state')
+          end
+
           context "when payment save failed" do
             before do
               allow_any_instance_of(Spree::Payment).to receive(:save).and_return(false)


### PR DESCRIPTION
It was removed because of invalid assumptions about the spree internals
(I assumed order gets advanced to `complete` on the final page).
