### PR TITLE
Raise specific exception for invalid state

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Changes:
 
 * Updated to work with Spree 3
 * Requests to PayU are done in separate controller, not in before filter
+* Added JS to toggle `payu_selected` class on form, so original
+  submit can be hidden with CSS
 
 Installation
 ------------
@@ -37,6 +39,8 @@ Don't forget to insert seller account details into `config/initializers/openpayu
 Pay with Payu button
 --------------------
 
+### Hiding original submit button
+
 `spree_payu_integration` adds a `payu_selected` css class to `form#checkout_form_payment`
 when PayU payment is selected, and removes this class if some other payment
 is choosen. To use this functionality, just add `//= require spree/frontend/spree_payu_integration` to your `application.js`.
@@ -45,6 +49,15 @@ This is so developer can conditionally hide "Save and Continue" button with css,
 so "Pay with PayU" button can be positioned in exact same spot than "Save and Continue".
 
 **REMEMBER: This is your job to write CSSes that hides "Save and Continue" button.**
+
+### Preventing double-clicking Payu button
+
+Please ensure you have some JavaScript in place that will prevent double-clicking
+PayU button. This can lead to lost carts, because first request
+will advance order to `completed` state, and the second one will raise
+an error, because you can only make payments for orders in `payment` state.
+
+**REMEMBER: This is your job to write JSes that prevents double clicking the button.**
 
 Testing
 -------

--- a/spec/controllers/spree/payu_controller_spec.rb
+++ b/spec/controllers/spree/payu_controller_spec.rb
@@ -316,6 +316,34 @@ RSpec.describe Spree::PayuController, type: :controller do
         end
       end
 
+      context "when there is no current order" do
+        before do
+          allow(controller).to receive(:current_order).and_return(nil)
+        end
+
+        subject { spree_post :pay, payment_method_id: '23' }
+
+        it 'raises ActiveRecord::RecordNotFound with meaningful message' do
+          expect {
+            subject
+          }.to raise_error ActiveRecord::RecordNotFound, /order not found/i
+        end
+      end
+
+      context "when order is not in payment state" do
+        before do
+          allow(order).to receive(:state).and_return(:completed)
+        end
+
+        subject { spree_post :pay, payment_method_id: '23' }
+
+        it 'raises RuntimeError with meaningful message' do
+          expect {
+            subject
+          }.to raise_error RuntimeError, /order not in payment state/i
+        end
+      end
+
       context "when payment method is not PayU" do
         let(:payment_method) { FactoryGirl.create :check_payment_method }
 


### PR DESCRIPTION
This ensures that `current_order` that is not in `payment` state will raise another exception, that just missing `current_order`.

As a bonus, added info about preventing double submit client side.
