### PR TITLE
Require proper spree_backend js

### DIFF
--- a/app/assets/javascripts/admin/spree_payu_integration.js
+++ b/app/assets/javascripts/admin/spree_payu_integration.js
@@ -1,1 +1,0 @@
-//= require admin/spree_backend

--- a/app/assets/javascripts/spree/backend/spree_payu_integration.js
+++ b/app/assets/javascripts/spree/backend/spree_payu_integration.js
@@ -1,0 +1,1 @@
+//= require spree/backend

--- a/app/assets/stylesheets/admin/spree_payu_integration.css
+++ b/app/assets/stylesheets/admin/spree_payu_integration.css
@@ -1,3 +1,0 @@
-/*
- *= require admin/spree_backend
-*/

--- a/app/assets/stylesheets/spree/backend/spree_payu_integration.css
+++ b/app/assets/stylesheets/spree/backend/spree_payu_integration.css
@@ -1,0 +1,3 @@
+/*
+ *= require spree/backend
+*/


### PR DESCRIPTION
When added to engine I work on as dependency, I encountered 

```
Sprockets::FileNotFound: couldn't find file 'admin/spree_backend'
  (in /home/dsawa/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/spree_payu_integration-92f52a630e18/app/assets/javascripts/admin/spree_payu_integration.js:1)
```

 I believe that `admin/spree_backend` path is not present in spree since 2.2
